### PR TITLE
chore: added robots and updated middleware so crawlers do not get 403

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,49 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      // General crawlers
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/api/',
+          '/_next/',
+          '/cart/',
+          '/checkout/',
+          '/account/',
+          '/admin/',
+        ],
+      },
+
+      // Facebook sharing scraper (fixes your 403 issue)
+      {
+        userAgent: 'facebookexternalhit',
+        allow: '/',
+      },
+      {
+        userAgent: 'Facebot',
+        allow: '/',
+      },
+
+      // Other major preview bots
+      {
+        userAgent: 'Twitterbot',
+        allow: '/',
+      },
+      {
+        userAgent: 'Slackbot',
+        allow: '/',
+      },
+      {
+        userAgent: 'Discordbot',
+        allow: '/',
+      },
+      {
+        userAgent: 'LinkedInBot',
+        allow: '/',
+      },
+    ],
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,41 @@
 import { createClient, OAuthStrategy } from "@wix/sdk";
 import { NextRequest, NextResponse } from "next/server";
 
-export const middleware = async (request:NextRequest) => {
+export const middleware = async (request: NextRequest) => {
+  const ua = request.headers.get("user-agent") || "";
+
+  // 👇 IMPORTANT: let crawlers through without Wix auth work
+  const isBot =
+    ua.includes("facebookexternalhit") ||
+    ua.includes("Facebot") ||
+    ua.includes("Twitterbot") ||
+    ua.includes("Slackbot") ||
+    ua.includes("Discordbot") ||
+    ua.includes("LinkedInBot") ||
+    ua.includes("bot");
+
+  if (isBot) {
+    return NextResponse.next();
+  }
+
   const cookies = request.cookies;
   const res = NextResponse.next();
 
-  if(cookies.get("refreshTokens")) {
+  if (cookies.get("refreshTokens")) {
     return res;
   }
 
   const wixClient = createClient({
-    auth:OAuthStrategy({clientId:process.env.NEXT_PUBLIC_WIX_CLIENT_ID!}),
+    auth: OAuthStrategy({
+      clientId: process.env.NEXT_PUBLIC_WIX_CLIENT_ID!,
+    }),
   });
 
   const tokens = await wixClient.auth.generateVisitorTokens();
 
   res.cookies.set("refreshToken", JSON.stringify(tokens.refreshToken), {
-    maxAge: 60 * 60 * 24 * 30
+    maxAge: 60 * 60 * 24 * 30,
   });
 
   return res;
-}
+};


### PR DESCRIPTION
sites trying to crawl cliffbait.com were getting 403 and 404 errors due to how the middleware was written and abscence of a robots.txt.

* this pr provides a robots.ts file that the nextjs appication builds to public/robots.txt
* this pr provides an updated middleware to allow useragents to proceed and bots ignore api calls.